### PR TITLE
fix: Poetry version 2.1.2 needs a pluging for `export`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
+# This project uses `uv` for dependency management. `uv export` works natively without Poetry plugins.
 [project]
 name = "fastapi-uv-starter"
 version = "0.1.0"


### PR DESCRIPTION
Closes #1